### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/src/agents/ParseAgent/ParseAgent.ts
+++ b/src/agents/ParseAgent/ParseAgent.ts
@@ -298,9 +298,20 @@ export class ParseAgent {
 
             // Get external references to find MITRE URL
             const externalRefs = technique.external_references || [];
-            const mitreRef = externalRefs.find((ref: any) =>
-                ref.source_name === 'mitre-attack' || ref.url?.includes('attack.mitre.org')
-            );
+            const mitreRef = externalRefs.find((ref: any) => {
+                if (ref.source_name === 'mitre-attack') return true;
+                if (ref.url) {
+                    try {
+                        const parsedUrl = new URL(ref.url);
+                        const allowedHosts = ['attack.mitre.org'];
+                        return allowedHosts.includes(parsedUrl.host);
+                    } catch (e) {
+                        this.logger.warn(`Invalid URL encountered: ${ref.url}`);
+                        return false;
+                    }
+                }
+                return false;
+            });
 
             // Extract technique ID from external_id if present
             const techniqueId = mitreRef?.external_id || technique.id.split('--').pop();


### PR DESCRIPTION
Potential fix for [https://github.com/jischell-msft/MCP-MitreAttack/security/code-scanning/2](https://github.com/jischell-msft/MCP-MitreAttack/security/code-scanning/2)

To fix the issue, the code should parse the URL and validate its host explicitly instead of using a substring check. This ensures that only URLs with the exact host `attack.mitre.org` (or its subdomains, if desired) are considered valid. The `URL` class from Node.js can be used to parse the URL and extract its host for comparison.

Steps to fix:
1. Replace the substring check (`includes('attack.mitre.org')`) with a host validation using the `URL` class.
2. Define a whitelist of allowed hosts (e.g., `['attack.mitre.org']`) and check if the parsed host matches one of these allowed hosts.
3. Update the relevant code block to implement this logic.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
