### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/src/api/routes/analyze-routes.ts
+++ b/src/api/routes/analyze-routes.ts
@@ -191,7 +191,13 @@ async function handleDocumentUpload(req: Request, res: Response, next: NextFunct
         // Clean up uploaded file in case of error
         if (req.file?.path) {
             try {
-                fs.unlinkSync(req.file.path);
+                const uploadDir = path.resolve('uploads'); // Define the safe root directory for uploads
+                const resolvedPath = path.resolve(req.file.path); // Normalize the file path
+                if (resolvedPath.startsWith(uploadDir)) { // Ensure the path is within the upload directory
+                    fs.unlinkSync(resolvedPath);
+                } else {
+                    logger.error(`Attempted to delete a file outside the upload directory: ${resolvedPath}`);
+                }
             } catch (e) {
                 logger.error(`Failed to clean up uploaded file: ${e}`);
             }


### PR DESCRIPTION
Potential fix for [https://github.com/jischell-msft/MCP-MitreAttack/security/code-scanning/1](https://github.com/jischell-msft/MCP-MitreAttack/security/code-scanning/1)

To address the issue, we will validate the `req.file.path` before using it in the `fs.unlinkSync` function. Specifically:
1. Use `path.resolve` to normalize the file path and remove any potentially malicious components like `..`.
2. Ensure the resolved path is within the expected upload directory (e.g., a predefined safe root directory).
3. If the path is not valid, log an error and avoid performing the deletion.

This approach ensures that only files within the designated upload directory can be deleted, mitigating the risk of path traversal attacks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
