### PR TITLE
Potential fix for code scanning alert no. 3: Double escaping or unescaping

### DIFF
--- a/src/agents/DocIngestAgent/extractors/RtfExtractor.ts
+++ b/src/agents/DocIngestAgent/extractors/RtfExtractor.ts
@@ -48,8 +48,8 @@ export class RtfExtractor {
             rtfString = rtfString.replace(/[\{\}]/g, '');
 
             // Replace escaped characters
-            rtfString = rtfString.replace(/\\\\/g, '\\');
             rtfString = rtfString.replace(/\\'/g, "'");
+            rtfString = rtfString.replace(/\\\\/g, '\\');
 
             return rtfString.trim();
         } catch (error) {


### PR DESCRIPTION
Potential fix for [https://github.com/jischell-msft/MCP-MitreAttack/security/code-scanning/3](https://github.com/jischell-msft/MCP-MitreAttack/security/code-scanning/3)

To fix the issue, the order of replacements should be adjusted to ensure that backslashes (`\`) are handled correctly. Specifically:
1. The replacement for escaped characters (`rtfString.replace(/\\\\/g, '\\')`) should be performed **last**, after all other replacements. This ensures that any backslashes introduced by earlier replacements are not unintentionally processed again.
2. No additional functionality or libraries are required for this fix, as it only involves reordering the existing replacement operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
