### PR TITLE
Potential fix for code scanning alert no. 4: Uncontrolled data used in path expression

### DIFF
--- a/src/api/routes/analyze.routes.ts
+++ b/src/api/routes/analyze.routes.ts
@@ -91,7 +91,18 @@ router.post('/', upload.single('document'), async (req, res, next) => {
         const validationResult = validateUploadedFile(req.file);
         if (!validationResult.valid) {
             // Remove invalid file
-            await fs.promises.unlink(req.file.path);
+            const uploadDir = path.join(process.cwd(), 'uploads');
+            const normalizedPath = path.resolve(req.file.path);
+            if (!normalizedPath.startsWith(uploadDir)) {
+                return res.status(400).json({
+                    success: false,
+                    error: {
+                       code: 'INVALID_DOCUMENT_PATH',
+                       message: 'The uploaded document path is invalid'
+                   }
+               });
+            }
+            await fs.promises.unlink(normalizedPath);
 
             return res.status(400).json({
                 success: false,


### PR DESCRIPTION
Potential fix for [https://github.com/jischell-msft/MCP-MitreAttack/security/code-scanning/4](https://github.com/jischell-msft/MCP-MitreAttack/security/code-scanning/4)

To address the issue, we need to ensure that the file path is validated before using it in the `fs.promises.unlink` function. Specifically:
1. Normalize the file path using `path.resolve` to remove any `..` segments.
2. Verify that the normalized path is within the intended upload directory (`path.join(process.cwd(), 'uploads')`).
3. If the path is not valid, reject the operation and return an appropriate error response.

This fix ensures that only files within the designated upload directory can be deleted, mitigating the risk of path traversal attacks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
