### PR TITLE
Potential fix for code scanning alert no. 5: Uncontrolled data used in path expression

### DIFF
--- a/src/api/routes/analyze.routes.ts
+++ b/src/api/routes/analyze.routes.ts
@@ -91,7 +91,13 @@ router.post('/', upload.single('document'), async (req, res, next) => {
         const validationResult = validateUploadedFile(req.file);
         if (!validationResult.valid) {
             // Remove invalid file
-            await fs.promises.unlink(req.file.path);
+            const uploadDir = path.join(process.cwd(), 'uploads');
+            const resolvedPath = path.resolve(req.file.path);
+            if (!resolvedPath.startsWith(uploadDir)) {
+                logger.error('Attempted to delete a file outside the upload directory', { path: req.file.path });
+            } else {
+                await fs.promises.unlink(resolvedPath);
+            }
 
             return res.status(400).json({
                 success: false,
@@ -137,7 +143,13 @@ router.post('/', upload.single('document'), async (req, res, next) => {
         // Clean up file on error
         if (req.file?.path) {
             try {
-                await fs.promises.unlink(req.file.path);
+                const uploadDir = path.join(process.cwd(), 'uploads');
+                const resolvedPath = path.resolve(req.file.path);
+                if (!resolvedPath.startsWith(uploadDir)) {
+                    logger.error('Attempted to delete a file outside the upload directory', { path: req.file.path });
+                } else {
+                    await fs.promises.unlink(resolvedPath);
+                }
             } catch (unlinkError) {
                 logger.error('Failed to delete uploaded file after error', {
                     path: req.file.path,


### PR DESCRIPTION
Potential fix for [https://github.com/jischell-msft/MCP-MitreAttack/security/code-scanning/5](https://github.com/jischell-msft/MCP-MitreAttack/security/code-scanning/5)

To address the issue, we will validate the file path before using it in the `fs.promises.unlink` function. Specifically:
1. Use `path.resolve` to normalize the file path and remove any `..` segments.
2. Ensure that the resolved file path is within the intended upload directory (`path.join(process.cwd(), 'uploads')`).
3. If the file path is not valid, log an error and avoid performing the deletion.

This approach ensures that only files within the designated upload directory can be deleted, mitigating the risk of directory traversal attacks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
