### PR TITLE
Potential fix for code scanning alert no. 5: Uncontrolled data used in path expression

### DIFF
--- a/src/api/routes/analyze.routes.ts
+++ b/src/api/routes/analyze.routes.ts
@@ -148,7 +148,17 @@ router.post('/', upload.single('document'), async (req, res, next) => {
         // Clean up file on error
         if (req.file?.path) {
             try {
-                await fs.promises.unlink(req.file.path);
+                const uploadDir = path.join(process.cwd(), 'uploads');
+                const normalizedPath = path.resolve(req.file.path);
+                if (normalizedPath.startsWith(uploadDir)) {
+                    await fs.promises.unlink(normalizedPath);
+                } else {
+                    logger.error('Attempted to delete a file outside the upload directory', {
+                        path: req.file.path,
+                        normalizedPath,
+                        uploadDir
+                    });
+                }
             } catch (unlinkError) {
                 logger.error('Failed to delete uploaded file after error', {
                     path: req.file.path,


### PR DESCRIPTION
Potential fix for [https://github.com/jischell-msft/MCP-MitreAttack/security/code-scanning/5](https://github.com/jischell-msft/MCP-MitreAttack/security/code-scanning/5)

To fix the issue, we need to ensure that the file path used in the cleanup logic is validated before being passed to `fs.promises.unlink`. This can be achieved by normalizing the path using `path.resolve` and verifying that it is within the intended upload directory. If the path is not valid, the cleanup operation should be skipped, and an error should be logged.

Steps to implement the fix:
1. Normalize the file path using `path.resolve`.
2. Check if the normalized path starts with the upload directory path.
3. Only proceed with the deletion if the path is valid; otherwise, log an error.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
